### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * **ZUM LCD Smart ConnectorAdapter** - Adapter to connect ZUM LCD Smart Controller to bqCNC.
 * **ZUM CNC** - Controller board for Witbox 2 printer.
 
-##License
+## License
 
 <img src="./doc/LICENSE/by-sa.png" width="200" align = "center">
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
